### PR TITLE
[Improvement] Keep torrent app in BG when opening magnet links.

### DIFF
--- a/CTCRecentsController.m
+++ b/CTCRecentsController.m
@@ -52,7 +52,10 @@
     
     BOOL isMagnetLink = [recentToDownload[@"isMagnetLink"] boolValue];
     if (isMagnetLink) {
-        [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:recentToDownload[@"url"]]];
+        // Open magnet links without bring app that handles them to the foreground
+        NSArray* urls = [NSArray arrayWithObject:[NSURL URLWithString:recentToDownload[@"url"]]];
+        [[NSWorkspace sharedWorkspace] openURLs:urls withAppBundleIdentifier:nil 
+            options:NSWorkspaceLaunchWithoutActivation additionalEventParamDescriptor:nil launchIdentifiers:nil];
     }
     else {
         [CTCScheduler.sharedScheduler downloadFile:recentToDownload

--- a/CTCScheduler.m
+++ b/CTCScheduler.m
@@ -241,7 +241,10 @@ NSString * const kCTCSchedulerLastUpdateStatusNotificationName = @"com.giorgioca
         
         // Open magnet link
         if (isMagnetLink) {
-            [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:feedFile[@"url"]]];
+            // Open magnet links without bring app that handles them to the foreground
+            NSArray* urls = [NSArray arrayWithObject:[NSURL URLWithString:feedFile[@"url"]]];
+            [[NSWorkspace sharedWorkspace] openURLs:urls withAppBundleIdentifier:nil 
+                options:NSWorkspaceLaunchWithoutActivation additionalEventParamDescriptor:nil launchIdentifiers:nil];
         }
         
         // Open normal torrent in torrent client, if requested


### PR DESCRIPTION
> **Disclosure:** I _am_ a developer, but I have very limited experience with Objective-C.

The problem: when Catch opens magnet links, it is handled by whatever application is set to handle magnet links. In my case, this app is Transmission. Despite whatever settings I use in Transmission, when that magnet link is opened, Transmission is brought to the front. This is especially undesirable when--like me--people use the same computer to run Transmission & co. as their media center. This means as we're peacefully minding our own business, watching--let's say Plex--and Catch catches a magnet link and Transmission pops up over our show!

I thought it was Transmission's fault, but it seems to be the way OS X handles opening URLs like magnet links. By default, it brings the app to the foreground. I found learned about this thanks to the user diamondsw on this thread: https://forums.plex.tv/index.php/topic/48190-transmission-keeps-popping-into-foreground-over-plex/

So I figured I'd be a good OSS contributor and fix this myself on Catch. As I mentioned before, tho... I'm no Obj-C dev. After much searching, I found out how to implement diamondsw's fix (see: http://zachwaugh.me/posts/opening-links-in-background-with-cocoa/), and apply it in this PR.

I tested this on the `1.8` branch and on the `master` branch and it worked for both.

I believe this only applies to magnet links and not to downloading torrent files and having Transmission watch the Downloads directory.
