### PR TITLE
HTTPS support for Feed URLs

### DIFF
--- a/CTCDefaults.h
+++ b/CTCDefaults.h
@@ -9,7 +9,7 @@ extern NSString * const kCTCDefaultsApplicationBugReportURL;
 extern NSString * const kCTCDefaultsApplicationFeatureRequestURL;
 extern NSString * const kCTCDefaultsApplicationHelpURL;
 extern NSString * const kCTCDefaultsServiceURL;
-extern NSString * const kCTCDefaultsServiceFeedURLPrefixRegex;
+extern NSString * const kCTCDefaultsServiceFeedURLRegex;
 
 
 @interface CTCDefaults : NSObject

--- a/CTCDefaults.h
+++ b/CTCDefaults.h
@@ -9,7 +9,7 @@ extern NSString * const kCTCDefaultsApplicationBugReportURL;
 extern NSString * const kCTCDefaultsApplicationFeatureRequestURL;
 extern NSString * const kCTCDefaultsApplicationHelpURL;
 extern NSString * const kCTCDefaultsServiceURL;
-extern NSString * const kCTCDefaultsServiceFeedURLPrefix;
+extern NSString * const kCTCDefaultsServiceFeedURLPrefixRegex;
 
 
 @interface CTCDefaults : NSObject

--- a/CTCDefaults.m
+++ b/CTCDefaults.m
@@ -11,7 +11,7 @@ NSString * const kCTCDefaultsApplicationBugReportURL = @"https://github.com/mips
 NSString * const kCTCDefaultsApplicationFeatureRequestURL = @"https://github.com/mipstian/catch/issues/new?labels=enhancement";
 NSString * const kCTCDefaultsApplicationHelpURL = @"https://github.com/mipstian/catch/wiki/Configuration";
 NSString * const kCTCDefaultsServiceURL = @"https://showrss.info/";
-NSString * const kCTCDefaultsServiceFeedURLPrefixRegex = @"^https?://showrss.info/rss.php\\?(.*)$";
+NSString * const kCTCDefaultsServiceFeedURLRegex = @"^https?://showrss.info/rss.php\\?(.*)$";
 
 // NSUserDefaults keys
 NSString * const kCTCDefaultsFeedURLKey = @"feedURL";
@@ -91,10 +91,10 @@ NSString * const kCTCDefaultsShouldRunHeadless = @"headless";
 
 + (BOOL)isFeedURLValid {
     NSString *feedURL = CTCDefaults.feedURL;
-    NSPredicate *feedURLTest = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", kCTCDefaultsServiceFeedURLPrefixRegex];
+    NSPredicate *feedURLTest = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", kCTCDefaultsServiceFeedURLRegex];
     if (![feedURLTest evaluateWithObject:feedURL]) {
         // The URL should match the prefix regex!
-        NSLog(@"Feed URL (%@) does not match Regex (%@)", feedURL, kCTCDefaultsServiceFeedURLPrefixRegex);
+        NSLog(@"Feed URL (%@) does not match Regex (%@)", feedURL, kCTCDefaultsServiceFeedURLRegex);
         return NO;
     }
     if ([feedURL rangeOfString:@"namespaces"].location == NSNotFound) {

--- a/CTCDefaults.m
+++ b/CTCDefaults.m
@@ -11,7 +11,7 @@ NSString * const kCTCDefaultsApplicationBugReportURL = @"https://github.com/mips
 NSString * const kCTCDefaultsApplicationFeatureRequestURL = @"https://github.com/mipstian/catch/issues/new?labels=enhancement";
 NSString * const kCTCDefaultsApplicationHelpURL = @"https://github.com/mipstian/catch/wiki/Configuration";
 NSString * const kCTCDefaultsServiceURL = @"http://showrss.info/";
-NSString * const kCTCDefaultsServiceFeedURLPrefix = @"http://showrss.info/rss.php?";
+NSString * const kCTCDefaultsServiceFeedURLPrefixRegex = @"^https?://showrss.info/rss.php\\?(.*)$";
 
 // NSUserDefaults keys
 NSString * const kCTCDefaultsFeedURLKey = @"feedURL";
@@ -91,9 +91,10 @@ NSString * const kCTCDefaultsShouldRunHeadless = @"headless";
 
 + (BOOL)isFeedURLValid {
     NSString *feedURL = CTCDefaults.feedURL;
-    if (![feedURL hasPrefix:kCTCDefaultsServiceFeedURLPrefix]) {
-        // The URL should start with the prefix!
-        NSLog(@"Feed URL (%@) does not start with expected prefix (%@)", feedURL, kCTCDefaultsServiceFeedURLPrefix);
+    NSPredicate *feedURLTest = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", kCTCDefaultsServiceFeedURLPrefixRegex];
+    if (![feedURLTest evaluateWithObject:feedURL]) {
+        // The URL should match the prefix regex!
+        NSLog(@"Feed URL (%@) does not match Regex (%@)", feedURL, kCTCDefaultsServiceFeedURLPrefixRegex);
         return NO;
     }
     if ([feedURL rangeOfString:@"namespaces"].location == NSNotFound) {

--- a/CTCDefaults.m
+++ b/CTCDefaults.m
@@ -10,7 +10,7 @@ NSString * const kCTCDefaultsApplicationWebsiteURL = @"http://github.com/mipstia
 NSString * const kCTCDefaultsApplicationBugReportURL = @"https://github.com/mipstian/catch/issues/new?labels=bug";
 NSString * const kCTCDefaultsApplicationFeatureRequestURL = @"https://github.com/mipstian/catch/issues/new?labels=enhancement";
 NSString * const kCTCDefaultsApplicationHelpURL = @"https://github.com/mipstian/catch/wiki/Configuration";
-NSString * const kCTCDefaultsServiceURL = @"http://showrss.info/";
+NSString * const kCTCDefaultsServiceURL = @"https://showrss.info/";
 NSString * const kCTCDefaultsServiceFeedURLPrefixRegex = @"^https?://showrss.info/rss.php\\?(.*)$";
 
 // NSUserDefaults keys

--- a/CTCDefaults.m
+++ b/CTCDefaults.m
@@ -91,8 +91,9 @@ NSString * const kCTCDefaultsShouldRunHeadless = @"headless";
 
 + (BOOL)isFeedURLValid {
     NSString *feedURL = CTCDefaults.feedURL;
-    NSPredicate *feedURLTest = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", kCTCDefaultsServiceFeedURLRegex];
-    if (![feedURLTest evaluateWithObject:feedURL]) {
+    NSRegularExpression *feedURLRegex = [NSRegularExpression regularExpressionWithPattern:kCTCDefaultsServiceFeedURLRegex options:0 error:nil];
+    NSTextCheckingResult *feedURLMatches = [feedURLRegex firstMatchInString:feedURL options:0 range:NSMakeRange(0, [feedURL length])];
+    if (!feedURLMatches) {
         // The URL should match the prefix regex!
         NSLog(@"Feed URL (%@) does not match Regex (%@)", feedURL, kCTCDefaultsServiceFeedURLRegex);
         return NO;

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Features:
 
   * ShowRSS client
   * Magnet support
+  * HTTPS support
   * Very low Processor/Memory usage
   * Only check your feed at night or in whatever period you choose
   * Organize torrents in folders based on show name


### PR DESCRIPTION
Now that ShowRSS finally supports HTTPS connections, everyone should (be able to) use them.