### PR TITLE
Support Running Scripts on each episode retrieved:

### DIFF
--- a/Catch.xcodeproj/project.pbxproj
+++ b/Catch.xcodeproj/project.pbxproj
@@ -151,13 +151,13 @@
 		44AB5B5F1DCE823A00AE6EB6 /* UserNotifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserNotifications.swift; path = Sources/App/UserNotifications.swift; sourceTree = "<group>"; };
 		44AB5B7F1DD54D7300AE6EB6 /* LoginItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LoginItem.swift; path = Sources/App/LoginItem.swift; sourceTree = "<group>"; };
 		44AB5B811DD5532C00AE6EB6 /* BundleInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BundleInfo.swift; path = Sources/App/BundleInfo.swift; sourceTree = "<group>"; };
-		44B363451DC99D1900128259 /* FeedChecker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FeedChecker.swift; path = Sources/App/FeedChecker.swift; sourceTree = "<group>"; };
+		44B363451DC99D1900128259 /* FeedChecker.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; name = FeedChecker.swift; path = Sources/App/FeedChecker.swift; sourceTree = "<group>"; tabWidth = 2; };
 		44B363471DC9B9FB00128259 /* Browser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Browser.swift; path = Sources/App/Browser.swift; sourceTree = "<group>"; };
 		44B363491DC9BF1B00128259 /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Config.swift; path = Sources/App/Config.swift; sourceTree = "<group>"; };
 		44B3634B1DCA6F7100128259 /* TimeOfDayMath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TimeOfDayMath.swift; path = Sources/App/TimeOfDayMath.swift; sourceTree = "<group>"; };
 		44B3634D1DCA744200128259 /* TimeOfDayMathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TimeOfDayMathTests.swift; path = Sources/Tests/TimeOfDayMathTests.swift; sourceTree = SOURCE_ROOT; };
 		44BA5D111DAEC0C300A9CE9A /* WindowShakeAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WindowShakeAnimation.swift; path = Sources/App/WindowShakeAnimation.swift; sourceTree = "<group>"; };
-		44BA5D131DAEC3B600A9CE9A /* RecentsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RecentsController.swift; path = Sources/App/RecentsController.swift; sourceTree = "<group>"; };
+		44BA5D131DAEC3B600A9CE9A /* RecentsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; name = RecentsController.swift; path = Sources/App/RecentsController.swift; sourceTree = "<group>"; tabWidth = 2; };
 		44BA5D151DAECF1A00A9CE9A /* RecentsCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RecentsCellView.swift; path = Sources/App/RecentsCellView.swift; sourceTree = "<group>"; };
 		44BA5D191DB81A8E00A9CE9A /* Application.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Application.swift; path = Sources/App/Application.swift; sourceTree = "<group>"; };
 		44BA5D1B1DB8220100A9CE9A /* MenuController.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; name = MenuController.swift; path = Sources/App/MenuController.swift; sourceTree = "<group>"; tabWidth = 2; };
@@ -438,14 +438,14 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1130;
 				TargetAttributes = {
 					446D8B551918D146007AB22D = {
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1130;
 						TestTargetID = 8D1107260486CEB800E47090;
 					};
 					44717AC31913A08700580054 = {
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1130;
 						SystemCapabilities = {
 							com.apple.Sandbox = {
 								enabled = 1;
@@ -453,7 +453,7 @@
 						};
 					};
 					8D1107260486CEB800E47090 = {
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1130;
 					};
 				};
 			};
@@ -462,12 +462,7 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
 				Italiano,
-				Italian,
 				"简体中文",
 				fr,
 				it,
@@ -482,6 +477,7 @@
 				nl,
 				Base,
 				pl,
+				ja,
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* Catch */;
 			projectDirPath = "";
@@ -661,7 +657,7 @@
 				OTHER_LDFLAGS = "-Wl,-rpath,@loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.giorgiocalderolla.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Catch;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -681,7 +677,7 @@
 				OTHER_LDFLAGS = "-Wl,-rpath,@loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.giorgiocalderolla.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Catch;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -822,7 +818,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.giorgiocalderolla.Catch.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -846,7 +842,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.giorgiocalderolla.Catch.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -865,7 +861,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_NAME}";
 				PRODUCT_NAME = "com.giorgiocalderolla.Catch.$(TARGET_NAME:rfc1034identifier)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = xpc;
 			};
 			name = Debug;
@@ -881,7 +877,7 @@
 				MACH_O_TYPE = mh_execute;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_NAME}";
 				PRODUCT_NAME = "com.giorgiocalderolla.Catch.$(TARGET_NAME:rfc1034identifier)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = xpc;
 			};
 			name = Release;

--- a/Catch.xcodeproj/xcshareddata/xcschemes/Catch (catalan).xcscheme
+++ b/Catch.xcodeproj/xcshareddata/xcschemes/Catch (catalan).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Catch.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -67,8 +65,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Catch.xcodeproj/xcshareddata/xcschemes/Catch (chinese simplified).xcscheme
+++ b/Catch.xcodeproj/xcshareddata/xcschemes/Catch (chinese simplified).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D1107260486CEB800E47090"
+            BuildableName = "Catch.app"
+            BlueprintName = "Catch"
+            ReferencedContainer = "container:Catch.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8D1107260486CEB800E47090"
-            BuildableName = "Catch.app"
-            BlueprintName = "Catch"
-            ReferencedContainer = "container:Catch.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -77,8 +75,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Catch.xcodeproj/xcshareddata/xcschemes/Catch (chinese traditional).xcscheme
+++ b/Catch.xcodeproj/xcshareddata/xcschemes/Catch (chinese traditional).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D1107260486CEB800E47090"
+            BuildableName = "Catch.app"
+            BlueprintName = "Catch"
+            ReferencedContainer = "container:Catch.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8D1107260486CEB800E47090"
-            BuildableName = "Catch.app"
-            BlueprintName = "Catch"
-            ReferencedContainer = "container:Catch.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -77,8 +75,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Catch.xcodeproj/xcshareddata/xcschemes/Catch (double german).xcscheme
+++ b/Catch.xcodeproj/xcshareddata/xcschemes/Catch (double german).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D1107260486CEB800E47090"
+            BuildableName = "Catch.app"
+            BlueprintName = "Catch"
+            ReferencedContainer = "container:Catch.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8D1107260486CEB800E47090"
-            BuildableName = "Catch.app"
-            BlueprintName = "Catch"
-            ReferencedContainer = "container:Catch.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -77,8 +75,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Catch.xcodeproj/xcshareddata/xcschemes/Catch (dutch).xcscheme
+++ b/Catch.xcodeproj/xcshareddata/xcschemes/Catch (dutch).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Catch.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -67,8 +65,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Catch.xcodeproj/xcshareddata/xcschemes/Catch (finnish).xcscheme
+++ b/Catch.xcodeproj/xcshareddata/xcschemes/Catch (finnish).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Catch.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -67,8 +65,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Catch.xcodeproj/xcshareddata/xcschemes/Catch (french).xcscheme
+++ b/Catch.xcodeproj/xcshareddata/xcschemes/Catch (french).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Catch.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -67,8 +65,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Catch.xcodeproj/xcshareddata/xcschemes/Catch (italian).xcscheme
+++ b/Catch.xcodeproj/xcshareddata/xcschemes/Catch (italian).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D1107260486CEB800E47090"
+            BuildableName = "Catch.app"
+            BlueprintName = "Catch"
+            ReferencedContainer = "container:Catch.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8D1107260486CEB800E47090"
-            BuildableName = "Catch.app"
-            BlueprintName = "Catch"
-            ReferencedContainer = "container:Catch.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -77,8 +75,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Catch.xcodeproj/xcshareddata/xcschemes/Catch (polish).xcscheme
+++ b/Catch.xcodeproj/xcshareddata/xcschemes/Catch (polish).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Catch.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -67,8 +65,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Catch.xcodeproj/xcshareddata/xcschemes/Catch (release).xcscheme
+++ b/Catch.xcodeproj/xcshareddata/xcschemes/Catch (release).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D1107260486CEB800E47090"
+            BuildableName = "Catch.app"
+            BlueprintName = "Catch"
+            ReferencedContainer = "container:Catch.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8D1107260486CEB800E47090"
-            BuildableName = "Catch.app"
-            BlueprintName = "Catch"
-            ReferencedContainer = "container:Catch.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"
@@ -71,8 +69,6 @@
             ReferencedContainer = "container:Catch.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Catch.xcodeproj/xcshareddata/xcschemes/Catch (spanish).xcscheme
+++ b/Catch.xcodeproj/xcshareddata/xcschemes/Catch (spanish).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Catch.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -67,8 +65,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Catch.xcodeproj/xcshareddata/xcschemes/Catch.xcscheme
+++ b/Catch.xcodeproj/xcshareddata/xcschemes/Catch.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D1107260486CEB800E47090"
+            BuildableName = "Catch.app"
+            BlueprintName = "Catch"
+            ReferencedContainer = "container:Catch.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8D1107260486CEB800E47090"
-            BuildableName = "Catch.app"
-            BlueprintName = "Catch"
-            ReferencedContainer = "container:Catch.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -71,8 +69,6 @@
             ReferencedContainer = "container:Catch.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Catch.xcodeproj/xcshareddata/xcschemes/CatchFeedHelper.xcscheme
+++ b/Catch.xcodeproj/xcshareddata/xcschemes/CatchFeedHelper.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:Catch.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Resources/App/Base.lproj/UI.xib
+++ b/Resources/App/Base.lproj/UI.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
-        <plugIn identifier="com.apple.automator.AutomatorPalette" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <plugIn identifier="com.apple.automator.AutomatorPalette" version="15702"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -33,6 +33,7 @@
             <connections>
                 <outlet property="automaticallyCheckForUpdatesCheckbox" destination="806" id="HZV-bf-GPz"/>
                 <outlet property="feedURLWarningImageView" destination="lIi-CM-MqY" id="Q3D-hE-heP"/>
+                <outlet property="scriptPathWarningImageView" destination="Wxg-TB-X3d" id="aoH-Fd-Ltg"/>
                 <outlet property="torrentsSavePathWarningImageView" destination="fwJ-Gq-K1U" id="aXv-um-IZf"/>
                 <outlet property="window" destination="552" id="Y5a-sh-KWH"/>
             </connections>
@@ -124,32 +125,33 @@
                     </connections>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="766" y="76"/>
         </menu>
         <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="552" userLabel="Preferences">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
-            <rect key="contentRect" x="310" y="248" width="700" height="317"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
-            <view key="contentView" id="553">
-                <rect key="frame" x="0.0" y="0.0" width="700" height="317"/>
+            <rect key="contentRect" x="310" y="248" width="700" height="500"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <view key="contentView" misplaced="YES" id="553">
+                <rect key="frame" x="0.0" y="0.0" width="700" height="500"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="616">
-                        <rect key="frame" x="20" y="61" width="660" height="236"/>
+                        <rect key="frame" x="20" y="61" width="660" height="422"/>
                         <font key="font" metaFont="system"/>
                         <tabViewItems>
                             <tabViewItem label="Feed" identifier="Feed" id="617">
                                 <view key="view" id="620">
-                                    <rect key="frame" x="0.0" y="0.0" width="660" height="236"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="660" height="422"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <box autoresizesSubviews="NO" borderType="line" title="RSS Feed" translatesAutoresizingMaskIntoConstraints="NO" id="621">
-                                            <rect key="frame" x="-3" y="123" width="666" height="113"/>
+                                            <rect key="frame" x="-3" y="309" width="666" height="113"/>
                                             <view key="contentView" id="bQf-OL-1yY">
                                                 <rect key="frame" x="3" y="3" width="660" height="95"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="785">
-                                                        <rect key="frame" x="13" y="62" width="67" height="17"/>
+                                                        <rect key="frame" x="13" y="63" width="67" height="16"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Feed URL:" id="786">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -157,7 +159,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="787">
-                                                        <rect key="frame" x="86" y="59" width="526" height="22"/>
+                                                        <rect key="frame" x="86" y="60" width="526" height="21"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="https://showrss.info/..." drawsBackground="YES" id="788">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -172,7 +174,7 @@
                                                         </connections>
                                                     </textField>
                                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="lIi-CM-MqY">
-                                                        <rect key="frame" x="627" y="61" width="18" height="18"/>
+                                                        <rect key="frame" x="627" y="62" width="18" height="18"/>
                                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="warning" id="Rda-Ff-O9x"/>
                                                     </imageView>
                                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="638">
@@ -186,7 +188,7 @@
                                                         </connections>
                                                     </button>
                                                     <datePicker verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="637">
-                                                        <rect key="frame" x="195" y="16" width="85" height="27"/>
+                                                        <rect key="frame" x="195" y="16" width="85" height="28"/>
                                                         <datePickerCell key="cell" borderStyle="bezel" alignment="left" id="646">
                                                             <font key="font" metaFont="system"/>
                                                             <date key="date" timeIntervalSinceReferenceDate="-595911600">
@@ -202,7 +204,7 @@
                                                         </connections>
                                                     </datePicker>
                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="636">
-                                                        <rect key="frame" x="283" y="20" width="27" height="17"/>
+                                                        <rect key="frame" x="283" y="20" width="27" height="16"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="and" id="647">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -210,7 +212,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <datePicker verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="635">
-                                                        <rect key="frame" x="316" y="16" width="85" height="27"/>
+                                                        <rect key="frame" x="316" y="16" width="85" height="28"/>
                                                         <datePickerCell key="cell" borderStyle="bezel" alignment="left" id="648">
                                                             <font key="font" metaFont="system"/>
                                                             <date key="date" timeIntervalSinceReferenceDate="-590868000">
@@ -249,13 +251,13 @@
                                             </constraints>
                                         </box>
                                         <box autoresizesSubviews="NO" borderType="line" title="Torrent Files" translatesAutoresizingMaskIntoConstraints="NO" id="622">
-                                            <rect key="frame" x="-3" y="-4" width="666" height="123"/>
+                                            <rect key="frame" x="-3" y="-4" width="666" height="309"/>
                                             <view key="contentView" id="i02-Cg-gRD">
-                                                <rect key="frame" x="3" y="3" width="660" height="105"/>
+                                                <rect key="frame" x="3" y="3" width="660" height="291"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="625">
-                                                        <rect key="frame" x="13" y="72" width="53" height="17"/>
+                                                        <rect key="frame" x="28" y="218" width="53" height="16"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Save to:" id="632">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -263,13 +265,13 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <amPathPopUpButton verticalHuggingPriority="750" canChooseDirectories="YES" canChooseExistingPaths="YES" placeholder="No Selection" translatesAutoresizingMaskIntoConstraints="NO" id="791">
-                                                        <rect key="frame" x="70" y="67" width="205" height="25"/>
+                                                        <rect key="frame" x="85" y="212" width="205" height="25"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="lfS-iv-ge7"/>
                                                         </constraints>
                                                         <amVariablePopUpButtonCell key="cell" type="push" title="Desktop" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1004" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" id="794">
                                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                            <font key="font" metaFont="menu"/>
+                                                            <font key="font" metaFont="system"/>
                                                             <menu key="menu" title="OtherViews" id="795"/>
                                                         </amVariablePopUpButtonCell>
                                                         <connections>
@@ -277,7 +279,7 @@
                                                         </connections>
                                                     </amPathPopUpButton>
                                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="624">
-                                                        <rect key="frame" x="13" y="34" width="227" height="18"/>
+                                                        <rect key="frame" x="28" y="155" width="227" height="18"/>
                                                         <buttonCell key="cell" type="check" title="Organize in folders by show name" bezelStyle="regularSquare" imagePosition="left" alignment="left" lineBreakMode="truncatingTail" state="on" inset="2" id="633">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                             <font key="font" metaFont="system"/>
@@ -287,7 +289,7 @@
                                                         </connections>
                                                     </button>
                                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="623">
-                                                        <rect key="frame" x="13" y="14" width="139" height="18"/>
+                                                        <rect key="frame" x="28" y="97" width="139" height="18"/>
                                                         <buttonCell key="cell" type="check" title="Open automatically" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="634">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                             <font key="font" metaFont="system"/>
@@ -297,25 +299,111 @@
                                                         </connections>
                                                     </button>
                                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fwJ-Gq-K1U">
-                                                        <rect key="frame" x="287" y="72" width="18" height="18"/>
+                                                        <rect key="frame" x="302" y="217" width="18" height="18"/>
                                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="warning" id="QCG-2j-VVy"/>
                                                     </imageView>
+                                                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Wxg-TB-X3d" userLabel="Script Path Warning Image View">
+                                                        <rect key="frame" x="338" y="22" width="18" height="18"/>
+                                                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="warning" id="mfy-ov-75l"/>
+                                                    </imageView>
+                                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="A1T-4t-3J7">
+                                                        <rect key="frame" x="28" y="22" width="89" height="18"/>
+                                                        <buttonCell key="cell" type="check" title="Run Script:" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Nwv-aw-ZWB">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="system"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <binding destination="658" name="value" keyPath="values.runScript" id="1V8-u3-aqd"/>
+                                                        </connections>
+                                                    </button>
+                                                    <amPathPopUpButton verticalHuggingPriority="750" imageHugsTitle="YES" canChooseFiles="YES" canChooseExistingPaths="YES" placeholder="No Selection" translatesAutoresizingMaskIntoConstraints="NO" id="6CK-W7-8e3">
+                                                        <rect key="frame" x="121" y="17" width="205" height="25"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="baK-ir-7S9"/>
+                                                        </constraints>
+                                                        <amVariablePopUpButtonCell key="cell" type="push" title="Desktop" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1004" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" id="BfV-Ke-OVO">
+                                                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="system"/>
+                                                            <menu key="menu" title="OtherViews" id="DhN-tz-Wiu"/>
+                                                        </amVariablePopUpButtonCell>
+                                                        <connections>
+                                                            <binding destination="658" name="enabled" keyPath="values.runScript" id="X9J-ZR-IHs"/>
+                                                            <binding destination="658" name="path" keyPath="values.scriptPath" id="olV-LJ-wQu"/>
+                                                        </connections>
+                                                    </amPathPopUpButton>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tc0-9v-8ZI">
+                                                        <rect key="frame" x="18" y="244" width="624" height="42"/>
+                                                        <textFieldCell key="cell" id="OIK-UB-Sf3">
+                                                            <font key="font" metaFont="message" size="11"/>
+                                                            <string key="title">If your RSS feed specifies .torrent files, they will be saved to the location below. If your RSS feed specifies magnet links, but you do not specify "Open automatically" below, then the magnet URLs will be saved as .webloc files to the location below (they will not be saved if "Open Automatically" is selected).</string>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="o0w-Bb-zpd">
+                                                        <rect key="frame" x="18" y="179" width="624" height="28"/>
+                                                        <textFieldCell key="cell" id="tl6-Se-k46">
+                                                            <font key="font" metaFont="message" size="11"/>
+                                                            <string key="title">If files are saved to the location above, then this option specifies that the files be organized according to the name of the show.</string>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3pE-6R-718">
+                                                        <rect key="frame" x="18" y="121" width="624" height="28"/>
+                                                        <textFieldCell key="cell" id="nWv-ND-TRL">
+                                                            <font key="font" metaFont="message" size="11"/>
+                                                            <string key="title">This option will open downloaded files automatically using the default application for the file type. Typically .torrent files and magnet links will be opened by a local torrent client.</string>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jUp-C6-ZFk">
+                                                        <rect key="frame" x="18" y="49" width="624" height="42"/>
+                                                        <textFieldCell key="cell" id="Pju-o8-sma">
+                                                            <font key="font" metaFont="message" size="11"/>
+                                                            <string key="title">This option will process downloaded episodes with a selected script, offering great flexibility for unique use cases. The script will be called with the path to the .torrent file if .torrent files result from your RSS feed, or with the magnet URI if magnet links are used.</string>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
                                                 </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="jUp-C6-ZFk" firstAttribute="top" secondItem="623" secondAttribute="bottom" constant="8" symbolic="YES" id="4R6-3T-R8L"/>
+                                                    <constraint firstItem="6CK-W7-8e3" firstAttribute="centerY" secondItem="A1T-4t-3J7" secondAttribute="centerY" id="6JD-E9-XL8"/>
+                                                    <constraint firstAttribute="trailing" secondItem="o0w-Bb-zpd" secondAttribute="trailing" constant="20" symbolic="YES" id="BgK-mt-Nxe"/>
+                                                    <constraint firstItem="Wxg-TB-X3d" firstAttribute="leading" secondItem="6CK-W7-8e3" secondAttribute="trailing" constant="15" id="DV5-eo-Aoo"/>
+                                                    <constraint firstItem="o0w-Bb-zpd" firstAttribute="leading" secondItem="tc0-9v-8ZI" secondAttribute="leading" id="E4b-DC-Fra"/>
+                                                    <constraint firstItem="791" firstAttribute="top" secondItem="tc0-9v-8ZI" secondAttribute="bottom" constant="8" symbolic="YES" id="K5z-ks-6w4"/>
+                                                    <constraint firstItem="624" firstAttribute="top" secondItem="o0w-Bb-zpd" secondAttribute="bottom" constant="8" symbolic="YES" id="LVu-rK-TUJ"/>
+                                                    <constraint firstItem="3pE-6R-718" firstAttribute="top" secondItem="624" secondAttribute="bottom" constant="8" symbolic="YES" id="Ou8-uN-m8u"/>
+                                                    <constraint firstItem="jUp-C6-ZFk" firstAttribute="leading" secondItem="tc0-9v-8ZI" secondAttribute="leading" id="R59-T6-H8q"/>
+                                                    <constraint firstItem="623" firstAttribute="top" secondItem="3pE-6R-718" secondAttribute="bottom" constant="8" symbolic="YES" id="ZIC-Cn-vmk"/>
+                                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Wxg-TB-X3d" secondAttribute="trailing" constant="15" id="aCh-UF-jhn"/>
+                                                    <constraint firstItem="o0w-Bb-zpd" firstAttribute="top" secondItem="791" secondAttribute="bottom" constant="8" symbolic="YES" id="aDd-Uh-HXd"/>
+                                                    <constraint firstAttribute="bottom" secondItem="6CK-W7-8e3" secondAttribute="bottom" constant="20" symbolic="YES" id="aM3-gy-uFs"/>
+                                                    <constraint firstItem="6CK-W7-8e3" firstAttribute="leading" secondItem="A1T-4t-3J7" secondAttribute="trailing" constant="8" symbolic="YES" id="bbd-8R-JIs"/>
+                                                    <constraint firstItem="3pE-6R-718" firstAttribute="leading" secondItem="tc0-9v-8ZI" secondAttribute="leading" id="hn9-rE-Vkj"/>
+                                                    <constraint firstItem="A1T-4t-3J7" firstAttribute="leading" secondItem="623" secondAttribute="leading" id="jKp-8x-BXj"/>
+                                                    <constraint firstAttribute="trailing" secondItem="tc0-9v-8ZI" secondAttribute="trailing" constant="20" symbolic="YES" id="mEF-RT-FCd"/>
+                                                    <constraint firstItem="Wxg-TB-X3d" firstAttribute="centerY" secondItem="6CK-W7-8e3" secondAttribute="centerY" id="quS-tZ-CZG"/>
+                                                    <constraint firstAttribute="trailing" secondItem="3pE-6R-718" secondAttribute="trailing" constant="20" symbolic="YES" id="sbP-V8-qY6"/>
+                                                    <constraint firstItem="6CK-W7-8e3" firstAttribute="top" secondItem="jUp-C6-ZFk" secondAttribute="bottom" constant="8" symbolic="YES" id="sdj-Xy-OMs"/>
+                                                    <constraint firstAttribute="trailing" secondItem="jUp-C6-ZFk" secondAttribute="trailing" constant="20" symbolic="YES" id="tHx-WJ-uo8"/>
+                                                    <constraint firstItem="tc0-9v-8ZI" firstAttribute="leading" secondItem="i02-Cg-gRD" secondAttribute="leading" constant="20" symbolic="YES" id="u18-Yo-K77"/>
+                                                </constraints>
                                             </view>
                                             <constraints>
                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="624" secondAttribute="trailing" constant="15" id="1GG-EY-Z1W"/>
                                                 <constraint firstItem="623" firstAttribute="leading" secondItem="624" secondAttribute="leading" id="5uF-v9-tnU"/>
                                                 <constraint firstItem="625" firstAttribute="baseline" secondItem="791" secondAttribute="baseline" id="G6U-8s-L9T"/>
-                                                <constraint firstAttribute="bottom" secondItem="623" secondAttribute="bottom" constant="15" id="MGf-4Q-vnz"/>
-                                                <constraint firstItem="624" firstAttribute="top" secondItem="791" secondAttribute="bottom" constant="20" id="OGQ-gC-ioe"/>
+                                                <constraint firstItem="tc0-9v-8ZI" firstAttribute="top" secondItem="622" secondAttribute="top" constant="20" id="Qxm-MB-4dl"/>
                                                 <constraint firstItem="625" firstAttribute="leading" secondItem="624" secondAttribute="leading" id="X5C-HD-i3q"/>
                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="623" secondAttribute="trailing" constant="15" id="c5c-wq-wWt"/>
-                                                <constraint firstItem="791" firstAttribute="top" secondItem="622" secondAttribute="top" constant="29" id="i1q-wO-PrP"/>
                                                 <constraint firstItem="fwJ-Gq-K1U" firstAttribute="leading" secondItem="791" secondAttribute="trailing" constant="15" id="iIc-xd-qXN"/>
                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="fwJ-Gq-K1U" secondAttribute="trailing" constant="15" id="kxl-JD-s9h"/>
                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="791" secondAttribute="trailing" constant="15" id="lUa-kR-xIL"/>
-                                                <constraint firstItem="625" firstAttribute="leading" secondItem="622" secondAttribute="leading" constant="15" id="mF8-Y1-hxm"/>
-                                                <constraint firstItem="623" firstAttribute="top" secondItem="624" secondAttribute="bottom" constant="6" symbolic="YES" id="orv-Bx-XxH"/>
+                                                <constraint firstItem="625" firstAttribute="leading" secondItem="622" secondAttribute="leading" constant="30" id="mF8-Y1-hxm"/>
                                                 <constraint firstItem="791" firstAttribute="centerY" secondItem="fwJ-Gq-K1U" secondAttribute="centerY" id="wzR-Ub-ddT"/>
                                                 <constraint firstItem="791" firstAttribute="leading" secondItem="625" secondAttribute="trailing" constant="8" symbolic="YES" id="xzk-UC-HsG"/>
                                             </constraints>
@@ -334,11 +422,11 @@
                             </tabViewItem>
                             <tabViewItem label="Tweaks" identifier="Tweaks" id="618">
                                 <view key="view" id="619">
-                                    <rect key="frame" x="0.0" y="0.0" width="660" height="236"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="660" height="419"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="980">
-                                            <rect key="frame" x="6" y="212" width="103" height="18"/>
+                                            <rect key="frame" x="6" y="395" width="103" height="18"/>
                                             <buttonCell key="cell" type="check" title="Open at login" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="981">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -348,7 +436,7 @@
                                             </connections>
                                         </button>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="AN1-pr-EUN">
-                                            <rect key="frame" x="6" y="192" width="228" height="18"/>
+                                            <rect key="frame" x="6" y="375" width="228" height="18"/>
                                             <buttonCell key="cell" type="check" title="Prevent system sleep when active" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="kuL-eb-cd0">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -358,7 +446,7 @@
                                             </connections>
                                         </button>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="806">
-                                            <rect key="frame" x="6" y="172" width="217" height="18"/>
+                                            <rect key="frame" x="6" y="355" width="217" height="18"/>
                                             <buttonCell key="cell" type="check" title="Automatically check for updates" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="807">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -454,13 +542,13 @@ DQ
                     <toolbarItem reference="613"/>
                 </defaultToolbarItems>
             </toolbar>
-            <point key="canvasLocation" x="139" y="119.5"/>
+            <point key="canvasLocation" x="132" y="365"/>
         </window>
         <customObject id="392" customClass="NSFontManager"/>
         <window title="Recent Episodes" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="aQN-n7-TBr" userLabel="Recent Episodes" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <rect key="contentRect" x="120" y="64" width="431" height="435"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <value key="minSize" type="size" width="200" height="300"/>
             <view key="contentView" id="gSi-VU-gYd">
                 <rect key="frame" x="0.0" y="0.0" width="431" height="435"/>
@@ -470,11 +558,11 @@ DQ
                         <rect key="frame" x="0.0" y="0.0" width="431" height="435"/>
                         <clipView key="contentView" drawsBackground="NO" id="KtZ-hY-aan">
                             <rect key="frame" x="0.0" y="0.0" width="431" height="435"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="55" viewBased="YES" id="oof-vB-WHt">
                                     <rect key="frame" x="0.0" y="0.0" width="431" height="435"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
@@ -500,7 +588,7 @@ DQ
                                                             <rect key="frame" x="20" y="0.0" width="377" height="57"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="cu4-uA-Wyj" userLabel="Torrent Name Text Field">
-                                                                    <rect key="frame" x="-2" y="32" width="85" height="17"/>
+                                                                    <rect key="frame" x="-2" y="33" width="85" height="16"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Torrent name" id="Cqp-ov-mrU">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -508,7 +596,7 @@ DQ
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5JR-n0-9Xs">
-                                                                    <rect key="frame" x="-2" y="10" width="96" height="17"/>
+                                                                    <rect key="frame" x="-2" y="12" width="96" height="16"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Download Date" id="kKb-I3-Ahb">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -582,7 +670,7 @@ DQ
         </window>
     </objects>
     <resources>
-        <image name="NSAdvanced" width="128" height="128"/>
+        <image name="NSAdvanced" width="32" height="32"/>
         <image name="NSRefreshFreestandingTemplate" width="14" height="14"/>
         <image name="rss" width="32" height="32"/>
         <image name="warning" width="18" height="18"/>

--- a/Sources/App/FeedChecker.swift
+++ b/Sources/App/FeedChecker.swift
@@ -129,6 +129,29 @@ final class FeedChecker {
           Browser.openInBackground(file: downloadedEpisode.localURL!.path)
         }
       }
+        
+      // Run a script on the torrent if requested
+      if Defaults.shared.runScript {
+        let task = Process()
+        let pipe = Pipe()
+        task.launchPath = Defaults.shared.scriptPath?.path
+        task.standardOutput = pipe
+        
+        if episode.isMagnetized {
+          // Run the script using the magnet URL as the argument.
+          task.arguments = [episode.url.absoluteString]
+        } else {
+          // Run the script using the file URL as the argument.
+          task.arguments = [downloadedEpisode.localURL!.path]
+        }
+        
+        task.launch()
+
+        let handle = pipe.fileHandleForReading
+        let data = handle.readDataToEndOfFile()
+        let printing = String (data: data, encoding: String.Encoding.utf8)
+        NSLog("%@", printing!)
+      }
       
       NSUserNotificationCenter.default.deliverNewEpisodeNotification(for: episode)
       

--- a/Sources/App/PreferencesController.swift
+++ b/Sources/App/PreferencesController.swift
@@ -11,6 +11,7 @@ private extension NSBindingName {
 class PreferencesController: NSWindowController {
   @IBOutlet private weak var feedURLWarningImageView: NSImageView!
   @IBOutlet private weak var torrentsSavePathWarningImageView: NSImageView!
+  @IBOutlet private weak var scriptPathWarningImageView: NSImageView!
   @IBOutlet private weak var automaticallyCheckForUpdatesCheckbox: NSButton!
   
   override func awakeFromNib() {
@@ -42,6 +43,7 @@ class PreferencesController: NSWindowController {
   private func refreshInvalidInputMarkers() {
     torrentsSavePathWarningImageView.image = Defaults.shared.isTorrentsSavePathValid ? #imageLiteral(resourceName: "success") : #imageLiteral(resourceName: "warning")
     feedURLWarningImageView.image = Defaults.shared.isFeedURLValid ? #imageLiteral(resourceName: "success") : #imageLiteral(resourceName: "error")
+    scriptPathWarningImageView.image = Defaults.shared.isScriptPathValid ? #imageLiteral(resourceName: "success") : #imageLiteral(resourceName: "error")
   }
   
   deinit {

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/python3
+#
+# Given a magnet link, send to Transmission via its RPC protocol.
+#
+# Uses requests
+# http://docs.python-requests.org/en/latest/
+#
+
+
+# Dependencies
+import sys
+import requests
+from json import dumps
+from sys import argv, exit
+from urllib.parse import unquote
+
+
+# Settings
+url = 'http://naseron:9092/transmission/rpc'
+username = ''
+password = ''
+
+
+# Functions
+
+# Get RPC Session ID
+def get_session_id():
+    sessionid_request = requests.get(url, auth=(username, password), verify=False)
+    return sessionid_request.headers['x-transmission-session-id']
+
+# Post Magnet Link
+def post_link(magnetlink, names, trackers):
+    sessionid = get_session_id()
+    if sessionid:
+        headers = {"X-Transmission-Session-Id": sessionid}
+        body = dumps({"method": "torrent-add", "arguments": {"filename": magnetlink}})
+        post_request = requests.post(url, data=body, headers=headers, auth=(username, password), verify=False)
+        if str(post_request.text).find("success") == -1:
+            sys.stderr.write(f'{argv[0]} ERROR: {post_request.text.rstrip()}; {magnetlink}\n')          
+        else:
+            all_names = ', '.join(names)
+            all_trackers = ', '.join(trackers)
+            sys.stderr.write(f'{argv[0]} SUCCESS: Names={all_names}; Trackers={all_trackers}\n') 
+
+# End of Functions
+
+# Main prog
+if __name__ == '__main__':
+
+    if len(argv) < 2:
+        sys.stderr.write(f'Usage: {argv[0]} [magnet_url]\n')
+        exit(1)
+        
+    if not argv[1].startswith('magnet'):
+        sys.stderr.write(f'This is not a magnet url: {argv[0]}\n')
+        exit(1)
+
+    names = []
+    trackers = []
+    for item in argv[1].split('&'):
+        decoded = unquote(item)
+        if decoded.startswith('dn='):
+            names.append(decoded.replace('dn=', ''))
+        if decoded.startswith('tr='):
+            trackers.append(decoded.replace('tr=', ''))
+    
+    post_link(argv[1], names, trackers)


### PR DESCRIPTION
- Updated to current Xcode.

- Updated to current Swift.

- Added GUI for running a script after each torrent is downloaded. This includes adding descriptive
  text fields for all of the options for clarity.

- The Recents window will now run the same script, if enabled, instead of opening the file with'
  the browser. If no script is defined, then previous behavior remains unaffected.

- Added a test_script which can be used for Transmission, for example.

- Catch will now execute a script after downloading episodes. To enable this, select
  "Run Script" in Preferences, and select a suitable script from the popup menu. This
  script will be executed independently of the "Open Automatically" Preference.

    - If the downloaded episode is a torrent file, then the script will be called with the path of
      the file as the argument. Since you're probably getting magnet links, this won't be useful.

    - If the downloaded episode is a magnet link, Catch will continue to save the stupid webloc files
      to your selected folder, but the script will be called with the magnet URL. You can then use
      this in your script as an RPC to Transmission, or any other flexible purpose.
